### PR TITLE
Removing old references to credentials files

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -6,13 +6,10 @@ MAINTAINER Sophie Fischer
 COPY dashboard/requirements.txt /source/requirements.txt
 RUN pip3 install -r /source/requirements.txt
 
-# TODO remove
-RUN mkdir ~/.aws
-COPY credentials.csv credentials.csv
-RUN echo [default] > ~/.aws/credentials
-RUN echo aws_access_key_id=$(awk -F',' 'FNR==2{print $1}' credentials.csv) >> ~/.aws/credentials
-RUN echo aws_secret_access_key=$(awk -F',' 'FNR==2{print $2}' credentials.csv) >> ~/.aws/credentials
-RUN aws configure set region us-east-1
+# Dummy credentials, not really needed to run locally DynamoDB but requested by the botocore API
+RUN aws configure set region us-east-1 \
+    && aws configure set aws_access_key_id abc \
+    && aws configure set aws_secret_access_key abc
 
 COPY dashboard/ /source
 WORKDIR /source

--- a/downloader/Dockerfile
+++ b/downloader/Dockerfile
@@ -5,7 +5,6 @@ COPY downloader/ /source
 # stop watchtower logging errors
 RUN  aws configure set region us-east-1
 
-COPY credentials.csv* /root/credentials.csv
 WORKDIR /source
 ENV PYTHONPATH=/shared:/shared/compiled_protobufs
 

--- a/functionalities/Dockerfile
+++ b/functionalities/Dockerfile
@@ -14,7 +14,6 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
 
 COPY functionalities/ /source
 COPY shared/ /shared
-COPY credentials.csv* credentials.csv
 
 WORKDIR /source
 CMD PYTHONPATH=/shared:/shared/compiled_protobufs python3 -u main.py

--- a/llm_functionalities/Dockerfile
+++ b/llm_functionalities/Dockerfile
@@ -42,7 +42,6 @@ ENV LANGUAGE en_US:en
 ENV TRANSFORMERS_CACHE /shared/file_system/cache/huggingface
 
 COPY llm_functionalities/requirements.txt /source/requirements.txt
-COPY credentials.csv* credentials.csv
 
 # uses a buildkit cache mount to try and share pip's cache between containers
 # during the build process

--- a/neural_functionalities/Dockerfile
+++ b/neural_functionalities/Dockerfile
@@ -43,7 +43,6 @@ ENV TRANSFORMERS_CACHE /shared/file_system/cache/huggingface
 
 
 COPY neural_functionalities/requirements.txt /source/requirements.txt
-COPY credentials.csv* credentials.csv
 
 # uses a buildkit cache mount to try and share pip's cache between containers
 # during the build process

--- a/offline/Dockerfile
+++ b/offline/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
 
 WORKDIR /source
 
-COPY credentials.csv* /root/credentials.csv
 COPY offline/requirements.txt /source/requirements.txt
 
 # uses a buildkit cache mount to try and share pip's cache between containers

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -17,7 +17,6 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     && aws configure set region us-east-1
 
 COPY tester/ /source
-COPY credentials.csv* credentials.csv
 
 WORKDIR /source
 


### PR DESCRIPTION
(no rush on reviewing this)

## Description

 I just noticed that we still had Dockerfile commands to copy credentials CSV files that should have been removed already, that's all this is. To make the dashboard work I also added dummy AWS credentials into its Dockerfile.

## Summary of files changed

Dockerfiles for: 

* `dashboard`
* `downloader`
* `functionalities`
* `llm_functionalities`
* `neural_functionalities`
* `offline`
* `tester`

## Testing

Should be enough to build the updated images and check things still work. Interacting through the `local_client` and loading the `dashboard` seem to be fine for me.

