### PR TITLE
Fix parsing of image_url_lookup.json

### DIFF
--- a/offline/augmenters/step_image_augmenter.py
+++ b/offline/augmenters/step_image_augmenter.py
@@ -36,11 +36,8 @@ class StepImageAugmenter(AbstractBatchStepAugmenter):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model, _ = clip.load("ViT-B/32", device=self.device, download_root=self.cache)
 
-        self.url_lookup_dict = {}
         with open(downloader.get_artefact_path('image_url_lookup'), 'rb') as url_lookup_file:
-            lookup_data = json.load(url_lookup_file)
-            for file_url_pair in lookup_data:
-                self.url_lookup_dict.update(file_url_pair)
+            self.url_lookup_dict = json.load(url_lookup_file)
 
         with open(downloader.get_artefact_path('image_list'), 'rb') as fp:
             self.all_images_list = pickle.load(fp)

--- a/offline/augmenters/thumbnail_image_augmenter.py
+++ b/offline/augmenters/thumbnail_image_augmenter.py
@@ -33,11 +33,8 @@ class ImageThumbnailAugmenter(AbstractBatchTaskGraphAugmenter):
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model, _ = clip.load("ViT-B/32", device=self.device, download_root=self.cache)
 
-        self.url_lookup_dict = {}
         with open(downloader.get_artefact_path('image_url_lookup'), 'rb') as url_lookup_file:
-            lookup_data = json.load(url_lookup_file)
-            for file_url_pair in lookup_data:
-                self.url_lookup_dict.update(file_url_pair)
+            self.url_lookup_dict = json.load(url_lookup_file)
 
         with open(downloader.get_artefact_path('image_list'), 'rb') as fp:
             self.all_images_list = pickle.load(fp)


### PR DESCRIPTION
## Summary 

The original version of `image_url_lookup.json` (used by the step image and thumbnail image augmenters) seems to have been a list of single-entry dicts, i.e.:
```python
[
    {file1: url1},
    {file2: url2},
    ...
]
```
so it needed some logic in the augmenters which use it to be parsed back to a single larger dict.

However after the OAT v2.0 updates, the current version of the file is already a single large dict. This causes an exception when the augmenters try to load it.

Since the file is already in the required format I've just changed the code to load and use it directly.

## Testing

Run the pipeline with the augmenters enabled, it should parse the JSON file successfully. 